### PR TITLE
Collapse Accordions upon groupLength change

### DIFF
--- a/packages/coordinator/src/components/Table/CardTableItem.tsx
+++ b/packages/coordinator/src/components/Table/CardTableItem.tsx
@@ -12,11 +12,15 @@ import Styles from "./GroupTable.module.scss";
 type CardTableItemProps<T> = {
   row: CardTableRow<T>;
   columns: CardTableColumn<T>[];
+  isExpanded: boolean;
+  handleExpandAccordion: () => void;
 };
 
 export default function CardTableItem<T>({
   row,
   columns,
+  isExpanded,
+  handleExpandAccordion,
 }: CardTableItemProps<T>) {
   const CalculatedContent = columns.flatMap((column) => {
     const cell = column.cellRenderer(row.rowData);
@@ -62,6 +66,8 @@ export default function CardTableItem<T>({
     <Accordion
       classes={{ root: classes.root, expanded: classes.expanded }}
       TransitionProps={{ unmountOnExit: true }}
+      expanded={isExpanded}
+      onChange={handleExpandAccordion}
     >
       <AccordionSummary expandIcon={<ExpandMore />}>
         {DisplayedContent}

--- a/packages/coordinator/src/components/Table/GroupTable.tsx
+++ b/packages/coordinator/src/components/Table/GroupTable.tsx
@@ -71,6 +71,8 @@ export default function GroupsTable<T>({
     CardTableRowGroup<T>[]
   >(groups);
 
+  const [expandedItems, setExpandedItems] = useState<string[]>([]);
+
   useEffect(() => {
     const sortGroup = (group: CardTableRowGroup<T>) => {
       let sortingFunction: SortFunction<T>;
@@ -99,6 +101,10 @@ export default function GroupsTable<T>({
     setInternallySortedGroups(sortedGroups);
   }, [sortByColumnIndex, isReversedSort, groups, columns]);
 
+  useEffect(() => {
+    setExpandedItems([]);
+  }, [groups.length]);
+
   const handleChangeSort = (nextIndex: number) => {
     if (!columns[nextIndex].sortBy) {
       return;
@@ -114,6 +120,20 @@ export default function GroupsTable<T>({
     setIsReversedSort(nextIsReversedSort);
   };
 
+  const handleExpandAccordion = (groupIndex: number, rowIndex: number) => {
+    let nextExpandedItems = [...expandedItems];
+
+    const nextRow = "" + groupIndex + rowIndex;
+
+    if (nextExpandedItems.includes(nextRow)) {
+      nextExpandedItems = nextExpandedItems.filter(
+        (expandedIndex) => expandedIndex !== nextRow
+      );
+    } else {
+      nextExpandedItems.push(nextRow);
+    }
+    setExpandedItems([...nextExpandedItems]);
+  };
   return (
     <div className={className || Styles["full-width"]}>
       <div className={Styles["component"]}>
@@ -145,11 +165,13 @@ export default function GroupsTable<T>({
           {internallySortedGroups.map((group, i) => (
             <div key={i} className={Styles["group"]}>
               <div>{group.groupLabel}</div>
-              {group.rowsInGroup.map((row, i) => (
+              {group.rowsInGroup.map((row, j) => (
                 <CardTableItem
                   row={row}
                   columns={columns}
+                  handleExpandAccordion={() => handleExpandAccordion(i, j)}
                   key={`${i}${sortByColumnIndex}${isReversedSort}`}
+                  isExpanded={expandedItems.includes("" + i + j)}
                 />
               ))}
             </div>


### PR DESCRIPTION
Fix steps:

1. Made MUI Accordion an explicitly controlled component
2. List of expanded Accordions
3. Refresh list upon Groups.length change. 
IMO, a naïve check of length (rather than group size as well) is sufficient,
and a total refresh should be expected as well - as the information should be treated as fresh information.

No pictures as this is a logical bugfix :) 