### PR TITLE
Not a bug

### DIFF
--- a/packages/coordinator/src/components/Table/CardTableItem.tsx
+++ b/packages/coordinator/src/components/Table/CardTableItem.tsx
@@ -50,7 +50,7 @@ export default function CardTableItem<T>({
     createStyles({
       root: {
         // From styles/layout/grid -> $gutter-vertical-small
-        marginBottom: ".5rem",
+        margin: ".5rem 0",
         // Overriding expanded:last-child
         "&$expanded": {
           margin: ".5rem 0",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45696895/125160600-89480d80-e186-11eb-9682-75da4e923246.png)

It's just a feature of the table card ;)
https://trello.com/c/tEFRsE8L/159-ui-coordinator-planned-appointments-remove-separating-line-when-there-is-only-1-appointment