### PR TITLE
Util/get appointment by

### DIFF
--- a/packages/functions/src/coordinator/CoordinatorBookAppointmentHandler.test.ts
+++ b/packages/functions/src/coordinator/CoordinatorBookAppointmentHandler.test.ts
@@ -14,6 +14,7 @@ import * as DonorDataAccessLayer from "../dal/DonorDataAccessLayer";
 import * as GroupDAL from "../dal/GroupsDataAccessLayer";
 import {
   deleteAppointmentsByIds,
+  getAppointmentById,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -23,7 +24,6 @@ import { notifyOnAppointmentBooked } from "../notifications/BookAppointmentNotif
 import { mocked } from "ts-jest/utils";
 import { DbAppointment, DbCoordinator, DbDonor } from "../function-types";
 import { deleteAdmin, setAdmin } from "../dal/AdminDataAccessLayer";
-import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 jest.setTimeout(7000);
 

--- a/packages/functions/src/coordinator/CoordinatorBookAppointmentHandler.test.ts
+++ b/packages/functions/src/coordinator/CoordinatorBookAppointmentHandler.test.ts
@@ -14,7 +14,6 @@ import * as DonorDataAccessLayer from "../dal/DonorDataAccessLayer";
 import * as GroupDAL from "../dal/GroupsDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentsByIds,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -24,6 +23,7 @@ import { notifyOnAppointmentBooked } from "../notifications/BookAppointmentNotif
 import { mocked } from "ts-jest/utils";
 import { DbAppointment, DbCoordinator, DbDonor } from "../function-types";
 import { deleteAdmin, setAdmin } from "../dal/AdminDataAccessLayer";
+import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 jest.setTimeout(7000);
 
@@ -154,10 +154,10 @@ test("Valid manual donor request books appointment with manual donor", async () 
   const data = response as FunctionsApi.BookAppointmentResponse;
   expect(data.status).toEqual(FunctionsApi.BookAppointmentStatus.SUCCESS);
 
-  const appointment = await getAppointmentsByIds([APPOINTMENT_TO_BOOK_2]);
-  expect(appointment[0].donorId).toEqual(MANUAL_DONOR_ID);
-  expect(appointment[0].assigningCoordinatorId).toEqual(COORDINATOR_ID);
-  expect(appointment[0].status).toEqual(AppointmentStatus.BOOKED);
+  const appointment = await getAppointmentById(APPOINTMENT_TO_BOOK_2);
+  expect(appointment.donorId).toEqual(MANUAL_DONOR_ID);
+  expect(appointment.assigningCoordinatorId).toEqual(COORDINATOR_ID);
+  expect(appointment.status).toEqual(AppointmentStatus.BOOKED);
 
   const bookedAppointment = data.bookedAppointment!;
   expect(bookedAppointment.id).toEqual(APPOINTMENT_TO_BOOK_2);
@@ -170,8 +170,8 @@ test("Valid manual donor request books appointment with manual donor", async () 
   expect(bookedAppointment.phone).toEqual(MANUAL_DONOR_DETAILS.phoneNumber);
   expect(bookedAppointment.bloodType).toEqual(MANUAL_DONOR_DETAILS.bloodType);
 
-  expect(appointment[0].lastChangeType).toEqual(BookingChange.BOOKED);
-  expect(Date.now() - appointment[0]?.lastChangeTime?.toMillis()!).toBeLessThan(
+  expect(appointment.lastChangeType).toEqual(BookingChange.BOOKED);
+  expect(Date.now() - appointment?.lastChangeTime?.toMillis()!).toBeLessThan(
     3_000
   );
 

--- a/packages/functions/src/coordinator/CoordinatorBookAppointmentHandler.test.ts
+++ b/packages/functions/src/coordinator/CoordinatorBookAppointmentHandler.test.ts
@@ -14,7 +14,7 @@ import * as DonorDataAccessLayer from "../dal/DonorDataAccessLayer";
 import * as GroupDAL from "../dal/GroupsDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentById,
+  getAppointmentByIdOrThrow,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -154,7 +154,7 @@ test("Valid manual donor request books appointment with manual donor", async () 
   const data = response as FunctionsApi.BookAppointmentResponse;
   expect(data.status).toEqual(FunctionsApi.BookAppointmentStatus.SUCCESS);
 
-  const appointment = await getAppointmentById(APPOINTMENT_TO_BOOK_2);
+  const appointment = await getAppointmentByIdOrThrow(APPOINTMENT_TO_BOOK_2);
   expect(appointment.donorId).toEqual(MANUAL_DONOR_ID);
   expect(appointment.assigningCoordinatorId).toEqual(COORDINATOR_ID);
   expect(appointment.status).toEqual(AppointmentStatus.BOOKED);

--- a/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
+++ b/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
@@ -9,6 +9,7 @@ import * as Functions from "../index";
 import { deleteAdmin, setAdmin } from "../dal/AdminDataAccessLayer";
 import {
   deleteAppointmentsByIds,
+  getAppointmentById,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -22,7 +23,6 @@ import * as DonorDAL from "../dal/DonorDataAccessLayer";
 import { deleteDonor } from "../dal/DonorDataAccessLayer";
 import { AppointmentStatus } from "@zm-blood-components/common/src";
 import { DbAppointment, DbCoordinator, DbDonor } from "../function-types";
-import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 jest.mock("../notifications/NotificationSender");
 const mockedNotifier = mocked(sendEmailToDonor);

--- a/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
+++ b/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
@@ -9,7 +9,6 @@ import * as Functions from "../index";
 import { deleteAdmin, setAdmin } from "../dal/AdminDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentsByIds,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -23,6 +22,7 @@ import * as DonorDAL from "../dal/DonorDataAccessLayer";
 import { deleteDonor } from "../dal/DonorDataAccessLayer";
 import { AppointmentStatus } from "@zm-blood-components/common/src";
 import { DbAppointment, DbCoordinator, DbDonor } from "../function-types";
+import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 jest.mock("../notifications/NotificationSender");
 const mockedNotifier = mocked(sendEmailToDonor);
@@ -113,8 +113,8 @@ test.each([true, false])(
 
     await callFunction(APPOINTMENT_ID, false, COORDINATOR_ID);
 
-    const appointments = await getAppointmentsByIds([APPOINTMENT_ID]);
-    expect(appointments).toHaveLength(0);
+    const appointment = await getAppointmentById(APPOINTMENT_ID);
+    expect(appointment).toBeUndefined();
 
     // Check notification is sent
     if (booked) {
@@ -148,12 +148,11 @@ test.each([true, false])(
 
     await callFunction(APPOINTMENT_ID, true, COORDINATOR_ID);
 
-    const appointments = await getAppointmentsByIds([APPOINTMENT_ID]);
-    expect(appointments).toHaveLength(1);
-    expect(appointments[0].id).toEqual(APPOINTMENT_ID);
-    expect(appointments[0].donorId).toEqual("");
-    expect(appointments[0].status).toEqual(AppointmentStatus.AVAILABLE);
-    expect(appointments[0].bookingTime).toBeUndefined();
+    const appointment = await getAppointmentById(APPOINTMENT_ID);
+    expect(appointment.id).toEqual(APPOINTMENT_ID);
+    expect(appointment.donorId).toEqual("");
+    expect(appointment.status).toEqual(AppointmentStatus.AVAILABLE);
+    expect(appointment.bookingTime).toBeUndefined();
 
     // Check notification is sent
     if (booked) {

--- a/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
+++ b/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
@@ -9,7 +9,7 @@ import * as Functions from "../index";
 import { deleteAdmin, setAdmin } from "../dal/AdminDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentById,
+  getAppointmentByIdOrThrow,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -113,8 +113,9 @@ test.each([true, false])(
 
     await callFunction(APPOINTMENT_ID, false, COORDINATOR_ID);
 
-    const appointment = await getAppointmentById(APPOINTMENT_ID);
-    expect(appointment).toBeUndefined();
+    const action = () => getAppointmentByIdOrThrow(APPOINTMENT_ID);
+
+    await expectAsyncThrows(action, "Appointment not found");
 
     // Check notification is sent
     if (booked) {
@@ -148,7 +149,7 @@ test.each([true, false])(
 
     await callFunction(APPOINTMENT_ID, true, COORDINATOR_ID);
 
-    const appointment = await getAppointmentById(APPOINTMENT_ID);
+    const appointment = await getAppointmentByIdOrThrow(APPOINTMENT_ID);
     expect(appointment.id).toEqual(APPOINTMENT_ID);
     expect(appointment.donorId).toEqual("");
     expect(appointment.status).toEqual(AppointmentStatus.AVAILABLE);

--- a/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
+++ b/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
@@ -95,7 +95,7 @@ test("No such appointment throws exception", async () => {
 
   const action = () => callFunction(APPOINTMENT_ID, false, COORDINATOR_ID);
 
-  await expectAsyncThrows(action, "Invalid appointment id");
+  await expectAsyncThrows(action, "Appointment not found");
 });
 
 test.each([true, false])(

--- a/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
+++ b/packages/functions/src/coordinator/DeleteAppointmentsHandler.test.ts
@@ -95,7 +95,10 @@ test("No such appointment throws exception", async () => {
 
   const action = () => callFunction(APPOINTMENT_ID, false, COORDINATOR_ID);
 
-  await expectAsyncThrows(action, "Appointment not found");
+  await expectAsyncThrows(
+    action,
+    `Appointment not found. Id ${APPOINTMENT_ID}`
+  );
 });
 
 test.each([true, false])(
@@ -115,7 +118,10 @@ test.each([true, false])(
 
     const action = () => getAppointmentByIdOrThrow(APPOINTMENT_ID);
 
-    await expectAsyncThrows(action, "Appointment not found");
+    await expectAsyncThrows(
+      action,
+      `Appointment not found. Id ${APPOINTMENT_ID}`
+    );
 
     // Check notification is sent
     if (booked) {

--- a/packages/functions/src/coordinator/DeleteAppointmentsHandler.ts
+++ b/packages/functions/src/coordinator/DeleteAppointmentsHandler.ts
@@ -16,14 +16,10 @@ export default async function (
 ) {
   const appointmentId = request.appointmentId;
 
-  const appointments = await AppointmentDataAccessLayer.getAppointmentsByIds([
-    appointmentId,
-  ]);
-  if (appointments.length !== 1) {
-    throw new Error("Invalid appointment id");
-  }
+  const appointment = await DbAppointmentUtils.getAppointmentByIdOrThrow(
+    appointmentId
+  );
 
-  const appointment = appointments[0];
   const appointmentHasRealDonor =
     DbAppointmentUtils.isAppointmentBooked(appointment) &&
     !DbAppointmentUtils.isManualDonorAppointment(appointment);

--- a/packages/functions/src/coordinator/DeleteAppointmentsHandler.ts
+++ b/packages/functions/src/coordinator/DeleteAppointmentsHandler.ts
@@ -16,9 +16,8 @@ export default async function (
 ) {
   const appointmentId = request.appointmentId;
 
-  const appointment = await DbAppointmentUtils.getAppointmentByIdOrThrow(
-    appointmentId
-  );
+  const appointment =
+    await AppointmentDataAccessLayer.getAppointmentByIdOrThrow(appointmentId);
 
   const appointmentHasRealDonor =
     DbAppointmentUtils.isAppointmentBooked(appointment) &&

--- a/packages/functions/src/coordinator/GetBookedApointmentHandler.test.ts
+++ b/packages/functions/src/coordinator/GetBookedApointmentHandler.test.ts
@@ -73,7 +73,10 @@ describe("GetBookedAppointment", function () {
     await createCoordinator(HOSPITAL);
 
     const action = () => callFunction(COORDINATOR_ID);
-    await expectAsyncThrows(action, "Appointment not found");
+    await expectAsyncThrows(
+      action,
+      `Appointment not found. Id ${APPOINTMENT_ID}`
+    );
   });
 
   test("Real donor is valid", async () => {

--- a/packages/functions/src/coordinator/GetBookedApointmentHandler.test.ts
+++ b/packages/functions/src/coordinator/GetBookedApointmentHandler.test.ts
@@ -73,7 +73,7 @@ describe("GetBookedAppointment", function () {
     await createCoordinator(HOSPITAL);
 
     const action = () => callFunction(COORDINATOR_ID);
-    await expectAsyncThrows(action, "Unexpected number of appointments");
+    await expectAsyncThrows(action, "Appointment not found");
   });
 
   test("Real donor is valid", async () => {

--- a/packages/functions/src/coordinator/GetBookedApointmentHandler.ts
+++ b/packages/functions/src/coordinator/GetBookedApointmentHandler.ts
@@ -1,5 +1,6 @@
 import { FunctionsApi, Hospital } from "@zm-blood-components/common";
 import * as AdminDataAccessLayer from "../dal/AdminDataAccessLayer";
+import * as AppointmentDataAccessLayer from "../dal/AppointmentDataAccessLayer";
 import { DbAppointment, DbCoordinator } from "../function-types";
 import { validateAppointmentPermissions } from "./UserValidator";
 import * as DbAppointmentUtils from "../utils/DbAppointmentUtils";
@@ -14,9 +15,10 @@ export default async function (
     throw Error(`User ${callerId} is not an admin`);
   }
 
-  const appointment = await DbAppointmentUtils.getAppointmentByIdOrThrow(
-    request.appointmentId
-  );
+  const appointment =
+    await AppointmentDataAccessLayer.getAppointmentByIdOrThrow(
+      request.appointmentId
+    );
 
   validateAppointment(appointment, coordinator);
 

--- a/packages/functions/src/coordinator/GetBookedApointmentHandler.ts
+++ b/packages/functions/src/coordinator/GetBookedApointmentHandler.ts
@@ -1,6 +1,5 @@
 import { FunctionsApi, Hospital } from "@zm-blood-components/common";
 import * as AdminDataAccessLayer from "../dal/AdminDataAccessLayer";
-import * as AppointmentDataAccessLayer from "../dal/AppointmentDataAccessLayer";
 import { DbAppointment, DbCoordinator } from "../function-types";
 import { validateAppointmentPermissions } from "./UserValidator";
 import * as DbAppointmentUtils from "../utils/DbAppointmentUtils";
@@ -15,18 +14,10 @@ export default async function (
     throw Error(`User ${callerId} is not an admin`);
   }
 
-  const appointments = await AppointmentDataAccessLayer.getAppointmentsByIds([
-    request.appointmentId,
-  ]);
-  if (appointments.length !== 1) {
-    console.error(
-      "Unexpected number of appointments, expected 1 got:",
-      appointments
-    );
-    throw Error(`Unexpected number of appointments`);
-  }
+  const appointment = await DbAppointmentUtils.getAppointmentByIdOrThrow(
+    request.appointmentId
+  );
 
-  const appointment = appointments[0];
   validateAppointment(appointment, coordinator);
 
   const bookedAppointment = await DbAppointmentUtils.toBookedAppointmentAsync(

--- a/packages/functions/src/dal/AppointmentDataAccessLayer.ts
+++ b/packages/functions/src/dal/AppointmentDataAccessLayer.ts
@@ -33,7 +33,7 @@ export async function getAppointmentByIdOrThrow(
   const appointment = foundAppointments[0];
 
   if (!appointment) {
-    throw new Error("Appointment not found");
+    throw new Error(`Appointment not found. Id ${appointmentId}`);
   }
 
   return appointment;

--- a/packages/functions/src/dal/AppointmentDataAccessLayer.ts
+++ b/packages/functions/src/dal/AppointmentDataAccessLayer.ts
@@ -26,6 +26,25 @@ export async function getAppointmentsByIds(
   return _.flatMap(snapshots, (s) => toDbAppointments(s));
 }
 
+export async function getAppointmentById(
+  appointmentId: string
+): Promise<DbAppointment | undefined> {
+  const foundAppointments = await getAppointmentsByIds([appointmentId]);
+  return foundAppointments[0];
+}
+
+export async function getAppointmentByIdOrThrow(
+  appointmentId: string
+): Promise<DbAppointment> {
+  const appointment = await getAppointmentById(appointmentId);
+
+  if (!appointment) {
+    throw new Error("Appointment not found");
+  }
+
+  return appointment;
+}
+
 export async function getAppointmentsCreatedByUserId(userId: string) {
   const appointments = (await admin
     .firestore()

--- a/packages/functions/src/dal/AppointmentDataAccessLayer.ts
+++ b/packages/functions/src/dal/AppointmentDataAccessLayer.ts
@@ -26,17 +26,11 @@ export async function getAppointmentsByIds(
   return _.flatMap(snapshots, (s) => toDbAppointments(s));
 }
 
-export async function getAppointmentById(
-  appointmentId: string
-): Promise<DbAppointment | undefined> {
-  const foundAppointments = await getAppointmentsByIds([appointmentId]);
-  return foundAppointments[0];
-}
-
 export async function getAppointmentByIdOrThrow(
   appointmentId: string
 ): Promise<DbAppointment> {
-  const appointment = await getAppointmentById(appointmentId);
+  const foundAppointments = await getAppointmentsByIds([appointmentId]);
+  const appointment = foundAppointments[0];
 
   if (!appointment) {
     throw new Error("Appointment not found");

--- a/packages/functions/src/donor/CancelAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/CancelAppointmentHandler.test.ts
@@ -4,7 +4,6 @@ import * as Functions from "../index";
 import { deleteDonor, setDonor } from "../dal/DonorDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentsByIds,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -19,6 +18,7 @@ import { mocked } from "ts-jest/utils";
 import { sampleUser } from "../testUtils/TestSamples";
 import { AppointmentStatus } from "@zm-blood-components/common/src";
 import { DbAppointment, DbDonor } from "../function-types";
+import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 jest.mock("../notifications/CancelAppointmentNotifier");
 const mockedNotifier = mocked(notifyOnCancelAppointment);
@@ -100,10 +100,10 @@ test("Valid request cancells appointment", async () => {
     },
   });
 
-  const appointment = await getAppointmentsByIds([APPOINTMENT_TO_CANCEL]);
-  expect(appointment[0].donorId).toEqual("");
-  expect(appointment[0].status).toEqual(AppointmentStatus.AVAILABLE);
-  expect(appointment[0].creatorUserId).toEqual("creatorUserId");
+  const appointment = await getAppointmentById(APPOINTMENT_TO_CANCEL);
+  expect(appointment.donorId).toEqual("");
+  expect(appointment.status).toEqual(AppointmentStatus.AVAILABLE);
+  expect(appointment.creatorUserId).toEqual("creatorUserId");
 
   expect(mockedNotifier).toBeCalledWith(
     expect.objectContaining({

--- a/packages/functions/src/donor/CancelAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/CancelAppointmentHandler.test.ts
@@ -4,7 +4,7 @@ import * as Functions from "../index";
 import { deleteDonor, setDonor } from "../dal/DonorDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentById,
+  getAppointmentByIdOrThrow,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -100,7 +100,7 @@ test("Valid request cancells appointment", async () => {
     },
   });
 
-  const appointment = await getAppointmentById(APPOINTMENT_TO_CANCEL);
+  const appointment = await getAppointmentByIdOrThrow(APPOINTMENT_TO_CANCEL);
   expect(appointment.donorId).toEqual("");
   expect(appointment.status).toEqual(AppointmentStatus.AVAILABLE);
   expect(appointment.creatorUserId).toEqual("creatorUserId");

--- a/packages/functions/src/donor/CancelAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/CancelAppointmentHandler.test.ts
@@ -4,6 +4,7 @@ import * as Functions from "../index";
 import { deleteDonor, setDonor } from "../dal/DonorDataAccessLayer";
 import {
   deleteAppointmentsByIds,
+  getAppointmentById,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -18,7 +19,6 @@ import { mocked } from "ts-jest/utils";
 import { sampleUser } from "../testUtils/TestSamples";
 import { AppointmentStatus } from "@zm-blood-components/common/src";
 import { DbAppointment, DbDonor } from "../function-types";
-import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 jest.mock("../notifications/CancelAppointmentNotifier");
 const mockedNotifier = mocked(notifyOnCancelAppointment);

--- a/packages/functions/src/donor/CancelAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/CancelAppointmentHandler.test.ts
@@ -70,7 +70,10 @@ test("No such appointments throws exception", async () => {
       }
     );
 
-  await expectAsyncThrows(action, "Appointment not found");
+  await expectAsyncThrows(
+    action,
+    `Appointment not found. Id ${APPOINTMENT_TO_CANCEL}`
+  );
 });
 
 test("Donor is not booked on this appointment throws exception", async () => {

--- a/packages/functions/src/donor/CancelAppointmentHandler.ts
+++ b/packages/functions/src/donor/CancelAppointmentHandler.ts
@@ -1,12 +1,12 @@
 import { FunctionsApi } from "@zm-blood-components/common";
 import { validateCancelAppointment } from "../common/CancelAppointmentHelper";
-import { setAppointment } from "../dal/AppointmentDataAccessLayer";
+import {
+  setAppointment,
+  getAppointmentByIdOrThrow,
+} from "../dal/AppointmentDataAccessLayer";
 import { getDonor } from "../dal/DonorDataAccessLayer";
 import { notifyOnCancelAppointment } from "../notifications/CancelAppointmentNotifier";
-import {
-  getAppointmentByIdOrThrow,
-  removeDonorFromDbAppointment,
-} from "../utils/DbAppointmentUtils";
+import { removeDonorFromDbAppointment } from "../utils/DbAppointmentUtils";
 
 export default async function (
   request: FunctionsApi.CancelAppointmentRequest,

--- a/packages/functions/src/donor/CancelAppointmentHandler.ts
+++ b/packages/functions/src/donor/CancelAppointmentHandler.ts
@@ -1,12 +1,12 @@
 import { FunctionsApi } from "@zm-blood-components/common";
 import { validateCancelAppointment } from "../common/CancelAppointmentHelper";
-import {
-  getAppointmentsByIds,
-  setAppointment,
-} from "../dal/AppointmentDataAccessLayer";
+import { setAppointment } from "../dal/AppointmentDataAccessLayer";
 import { getDonor } from "../dal/DonorDataAccessLayer";
 import { notifyOnCancelAppointment } from "../notifications/CancelAppointmentNotifier";
-import { removeDonorFromDbAppointment } from "../utils/DbAppointmentUtils";
+import {
+  getAppointmentByIdOrThrow,
+  removeDonorFromDbAppointment,
+} from "../utils/DbAppointmentUtils";
 
 export default async function (
   request: FunctionsApi.CancelAppointmentRequest,
@@ -18,13 +18,7 @@ export default async function (
     throw new Error("No appointment to cancel");
   }
 
-  const foundAppointments = await getAppointmentsByIds([request.appointmentId]);
-
-  if (foundAppointments.length !== 1) {
-    throw new Error("Appointment not found");
-  }
-
-  const appointment = foundAppointments[0];
+  const appointment = await getAppointmentByIdOrThrow(request.appointmentId);
 
   validateCancelAppointment(appointment, donorId);
 

--- a/packages/functions/src/donor/CompleteAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/CompleteAppointmentHandler.test.ts
@@ -72,7 +72,10 @@ test("No such appointments throws exception", async () => {
       }
     );
 
-  await expectAsyncThrows(action, "Appointment not found");
+  await expectAsyncThrows(
+    action,
+    `Appointment not found. Id ${APPOINTMENT_TO_COMPLETE}`
+  );
 });
 
 test("Donor is not booked on this appointment throws exception", async () => {

--- a/packages/functions/src/donor/CompleteAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/CompleteAppointmentHandler.test.ts
@@ -10,6 +10,7 @@ import * as Functions from "../index";
 import { deleteDonor, setDonor } from "../dal/DonorDataAccessLayer";
 import {
   deleteAppointmentsByIds,
+  getAppointmentById,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -17,7 +18,6 @@ import * as admin from "firebase-admin";
 import { sampleUser } from "../testUtils/TestSamples";
 import { DbAppointment, DbCoordinator, DbDonor } from "../function-types";
 import { deleteAdmin, setAdmin } from "../dal/AdminDataAccessLayer";
-import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 const wrapped = firebaseFunctionsTest.wrap(
   Functions[FunctionsApi.CompleteAppointmentFunctionName]

--- a/packages/functions/src/donor/CompleteAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/CompleteAppointmentHandler.test.ts
@@ -10,7 +10,7 @@ import * as Functions from "../index";
 import { deleteDonor, setDonor } from "../dal/DonorDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentById,
+  getAppointmentByIdOrThrow,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -136,7 +136,7 @@ test("Valid request when caller is a coordinator", async () => {
     },
   });
 
-  const appointment = await getAppointmentById(APPOINTMENT_TO_COMPLETE);
+  const appointment = await getAppointmentByIdOrThrow(APPOINTMENT_TO_COMPLETE);
   expect(appointment.donationDoneTimeMillis).toBeTruthy();
   expect(appointment.status).toEqual(AppointmentStatus.NOSHOW);
   expect(appointment.lastChangeType).toEqual(BookingChange.NOSHOW);
@@ -155,7 +155,9 @@ test.each([true, false])(
       },
     });
 
-    const appointment = await getAppointmentById(APPOINTMENT_TO_COMPLETE);
+    const appointment = await getAppointmentByIdOrThrow(
+      APPOINTMENT_TO_COMPLETE
+    );
     expect(appointment.donationDoneTimeMillis).toBeTruthy();
     expect(appointment.status).toEqual(
       isNoShow ? AppointmentStatus.NOSHOW : AppointmentStatus.COMPLETED

--- a/packages/functions/src/donor/CompleteAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/CompleteAppointmentHandler.test.ts
@@ -10,7 +10,6 @@ import * as Functions from "../index";
 import { deleteDonor, setDonor } from "../dal/DonorDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentsByIds,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -18,6 +17,7 @@ import * as admin from "firebase-admin";
 import { sampleUser } from "../testUtils/TestSamples";
 import { DbAppointment, DbCoordinator, DbDonor } from "../function-types";
 import { deleteAdmin, setAdmin } from "../dal/AdminDataAccessLayer";
+import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 const wrapped = firebaseFunctionsTest.wrap(
   Functions[FunctionsApi.CompleteAppointmentFunctionName]
@@ -136,11 +136,11 @@ test("Valid request when caller is a coordinator", async () => {
     },
   });
 
-  const appointment = await getAppointmentsByIds([APPOINTMENT_TO_COMPLETE]);
-  expect(appointment[0].donationDoneTimeMillis).toBeTruthy();
-  expect(appointment[0].status).toEqual(AppointmentStatus.NOSHOW);
-  expect(appointment[0].lastChangeType).toEqual(BookingChange.NOSHOW);
-  expect(appointment[0].creatorUserId).toEqual(COORDINATOR_ID);
+  const appointment = await getAppointmentById(APPOINTMENT_TO_COMPLETE);
+  expect(appointment.donationDoneTimeMillis).toBeTruthy();
+  expect(appointment.status).toEqual(AppointmentStatus.NOSHOW);
+  expect(appointment.lastChangeType).toEqual(BookingChange.NOSHOW);
+  expect(appointment.creatorUserId).toEqual(COORDINATOR_ID);
 });
 
 test.each([true, false])(
@@ -155,15 +155,15 @@ test.each([true, false])(
       },
     });
 
-    const appointment = await getAppointmentsByIds([APPOINTMENT_TO_COMPLETE]);
-    expect(appointment[0].donationDoneTimeMillis).toBeTruthy();
-    expect(appointment[0].status).toEqual(
+    const appointment = await getAppointmentById(APPOINTMENT_TO_COMPLETE);
+    expect(appointment.donationDoneTimeMillis).toBeTruthy();
+    expect(appointment.status).toEqual(
       isNoShow ? AppointmentStatus.NOSHOW : AppointmentStatus.COMPLETED
     );
-    expect(appointment[0].lastChangeType).toEqual(
+    expect(appointment.lastChangeType).toEqual(
       isNoShow ? BookingChange.NOSHOW : BookingChange.COMPLETED
     );
-    expect(appointment[0].creatorUserId).toEqual(COORDINATOR_ID);
+    expect(appointment.creatorUserId).toEqual(COORDINATOR_ID);
   }
 );
 

--- a/packages/functions/src/donor/CompleteAppointmentHandler.ts
+++ b/packages/functions/src/donor/CompleteAppointmentHandler.ts
@@ -27,9 +27,8 @@ export async function completeAppointmentFunc(
   isNoshow: boolean,
   coordinatorId?: string
 ): Promise<FunctionsApi.CompleteAppointmentResponse> {
-  const appointment = await DbAppointmentUtils.getAppointmentByIdOrThrow(
-    appointmentId
-  );
+  const appointment =
+    await AppointmentDataAccessLayer.getAppointmentByIdOrThrow(appointmentId);
 
   if (coordinatorId) {
     await validateAppointmentEditPermissions(

--- a/packages/functions/src/donor/CompleteAppointmentHandler.ts
+++ b/packages/functions/src/donor/CompleteAppointmentHandler.ts
@@ -27,14 +27,10 @@ export async function completeAppointmentFunc(
   isNoshow: boolean,
   coordinatorId?: string
 ): Promise<FunctionsApi.CompleteAppointmentResponse> {
-  const appointmentToComplete =
-    await AppointmentDataAccessLayer.getAppointmentsByIds([appointmentId]);
+  const appointment = await DbAppointmentUtils.getAppointmentByIdOrThrow(
+    appointmentId
+  );
 
-  if (appointmentToComplete.length !== 1) {
-    throw new Error("Appointment not found");
-  }
-
-  const appointment = appointmentToComplete[0];
   if (coordinatorId) {
     await validateAppointmentEditPermissions(
       coordinatorId,

--- a/packages/functions/src/donor/DonorBookAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/DonorBookAppointmentHandler.test.ts
@@ -8,7 +8,7 @@ import * as Functions from "../index";
 import * as DonorDataAccessLayer from "../dal/DonorDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentById,
+  getAppointmentByIdOrThrow,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -125,7 +125,7 @@ test("Valid request books appointment", async () => {
     },
   });
 
-  const appointment = await getAppointmentById(APPOINTMENT_TO_BOOK_2);
+  const appointment = await getAppointmentByIdOrThrow(APPOINTMENT_TO_BOOK_2);
   expect(appointment.donorId).toEqual(DONOR_ID);
   expect(appointment.status).toEqual(AppointmentStatus.BOOKED);
 

--- a/packages/functions/src/donor/DonorBookAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/DonorBookAppointmentHandler.test.ts
@@ -8,6 +8,7 @@ import * as Functions from "../index";
 import * as DonorDataAccessLayer from "../dal/DonorDataAccessLayer";
 import {
   deleteAppointmentsByIds,
+  getAppointmentById,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -18,7 +19,6 @@ import { mocked } from "ts-jest/utils";
 import { BookAppointmentStatus } from "../../../common/src/functions-api";
 import { AppointmentStatus } from "@zm-blood-components/common/src";
 import { DbAppointment, DbDonor } from "../function-types";
-import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 const wrapped = firebaseFunctionsTest.wrap(
   Functions[FunctionsApi.DonorBookAppointmentFunctionName]

--- a/packages/functions/src/donor/DonorBookAppointmentHandler.test.ts
+++ b/packages/functions/src/donor/DonorBookAppointmentHandler.test.ts
@@ -8,7 +8,6 @@ import * as Functions from "../index";
 import * as DonorDataAccessLayer from "../dal/DonorDataAccessLayer";
 import {
   deleteAppointmentsByIds,
-  getAppointmentsByIds,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
@@ -19,6 +18,7 @@ import { mocked } from "ts-jest/utils";
 import { BookAppointmentStatus } from "../../../common/src/functions-api";
 import { AppointmentStatus } from "@zm-blood-components/common/src";
 import { DbAppointment, DbDonor } from "../function-types";
+import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 const wrapped = firebaseFunctionsTest.wrap(
   Functions[FunctionsApi.DonorBookAppointmentFunctionName]
@@ -125,9 +125,9 @@ test("Valid request books appointment", async () => {
     },
   });
 
-  const appointment = await getAppointmentsByIds([APPOINTMENT_TO_BOOK_2]);
-  expect(appointment[0].donorId).toEqual(DONOR_ID);
-  expect(appointment[0].status).toEqual(AppointmentStatus.BOOKED);
+  const appointment = await getAppointmentById(APPOINTMENT_TO_BOOK_2);
+  expect(appointment.donorId).toEqual(DONOR_ID);
+  expect(appointment.status).toEqual(AppointmentStatus.BOOKED);
 
   const data = response as FunctionsApi.BookAppointmentResponse;
   expect(data.status).toEqual(BookAppointmentStatus.SUCCESS);
@@ -136,15 +136,15 @@ test("Valid request books appointment", async () => {
   expect(bookedAppointment.id).toEqual(APPOINTMENT_TO_BOOK_2);
   expect(bookedAppointment.donorId).toEqual(DONOR_ID);
 
-  expect(appointment[0].lastChangeType).toEqual(BookingChange.BOOKED);
-  expect(Date.now() - appointment[0]?.lastChangeTime?.toMillis()!).toBeLessThan(
+  expect(appointment.lastChangeType).toEqual(BookingChange.BOOKED);
+  expect(Date.now() - appointment?.lastChangeTime?.toMillis()!).toBeLessThan(
     3_000
   );
 
   expect(bookedAppointment.recentChangeType).toEqual(BookingChange.BOOKED);
 
   expect(mockedNotifier).toBeCalledWith(
-    appointment[0],
+    appointment,
     expect.objectContaining({
       firstName: "firstName",
       email: "email@email.com",

--- a/packages/functions/src/notifications/CompleteAppointmentApi.test.ts
+++ b/packages/functions/src/notifications/CompleteAppointmentApi.test.ts
@@ -1,6 +1,6 @@
 import * as Functions from "../index";
 import { expectAsyncThrows } from "../testUtils/TestUtils";
-import { deleteDonor, getDonor } from "../dal/DonorDataAccessLayer";
+import { deleteDonor } from "../dal/DonorDataAccessLayer";
 import { saveTestDonor } from "../testUtils/TestSamples";
 import "../testUtils/FirebaseTestUtils";
 import { Request } from "firebase-functions/lib/providers/https";
@@ -10,9 +10,9 @@ import { DbAppointment } from "../function-types";
 import { AppointmentStatus, Hospital } from "@zm-blood-components/common/src";
 import {
   deleteAppointmentsByIds,
-  getAppointmentsByIds,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
+import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 const DONOR_ID = "CompleteUserId";
 const APPOINTMENT_ID = "CompleteAppointmentID";
@@ -44,8 +44,8 @@ test("Valid request to complete", async () => {
 
   await callTarget(APPOINTMENT_ID, DONOR_ID);
 
-  const appointment = await getAppointmentsByIds([APPOINTMENT_ID]);
-  expect(appointment[0].status).toEqual(AppointmentStatus.COMPLETED);
+  const appointment = await getAppointmentById(APPOINTMENT_ID);
+  expect(appointment.status).toEqual(AppointmentStatus.COMPLETED);
 });
 
 async function callTarget(appointmentId: string, donorId: string) {

--- a/packages/functions/src/notifications/CompleteAppointmentApi.test.ts
+++ b/packages/functions/src/notifications/CompleteAppointmentApi.test.ts
@@ -10,9 +10,9 @@ import { DbAppointment } from "../function-types";
 import { AppointmentStatus, Hospital } from "@zm-blood-components/common/src";
 import {
   deleteAppointmentsByIds,
+  getAppointmentById,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
-import { getAppointmentById } from "../utils/DbAppointmentUtils";
 
 const DONOR_ID = "CompleteUserId";
 const APPOINTMENT_ID = "CompleteAppointmentID";

--- a/packages/functions/src/notifications/CompleteAppointmentApi.test.ts
+++ b/packages/functions/src/notifications/CompleteAppointmentApi.test.ts
@@ -10,7 +10,7 @@ import { DbAppointment } from "../function-types";
 import { AppointmentStatus, Hospital } from "@zm-blood-components/common/src";
 import {
   deleteAppointmentsByIds,
-  getAppointmentById,
+  getAppointmentByIdOrThrow,
   setAppointment,
 } from "../dal/AppointmentDataAccessLayer";
 
@@ -44,7 +44,7 @@ test("Valid request to complete", async () => {
 
   await callTarget(APPOINTMENT_ID, DONOR_ID);
 
-  const appointment = await getAppointmentById(APPOINTMENT_ID);
+  const appointment = await getAppointmentByIdOrThrow(APPOINTMENT_ID);
   expect(appointment.status).toEqual(AppointmentStatus.COMPLETED);
 });
 

--- a/packages/functions/src/utils/DbAppointmentUtils.ts
+++ b/packages/functions/src/utils/DbAppointmentUtils.ts
@@ -9,6 +9,7 @@ import {
 import * as admin from "firebase-admin";
 import { DbAppointment, DbDonor } from "../function-types";
 import * as DonorDataAccessLayer from "../dal/DonorDataAccessLayer";
+import { getAppointmentsByIds } from "../dal/AppointmentDataAccessLayer";
 
 export function removeDonorFromDbAppointment(
   appointment: DbAppointment
@@ -118,6 +119,25 @@ export function toBookedAppointmentSync(
       donor.bloodType
     );
   }
+}
+
+export async function getAppointmentById(
+  appointmentId: string
+): Promise<DbAppointment> {
+  const foundAppointments = await getAppointmentsByIds([appointmentId]);
+  return foundAppointments[0];
+}
+
+export async function getAppointmentByIdOrThrow(
+  appointmentId: string
+): Promise<DbAppointment> {
+  const appointment = await getAppointmentById(appointmentId);
+
+  if (!appointment) {
+    throw new Error("Appointment not found");
+  }
+
+  return appointment;
 }
 
 function manuallyBookedAppointmentToBookedAppointment(

--- a/packages/functions/src/utils/DbAppointmentUtils.ts
+++ b/packages/functions/src/utils/DbAppointmentUtils.ts
@@ -9,7 +9,6 @@ import {
 import * as admin from "firebase-admin";
 import { DbAppointment, DbDonor } from "../function-types";
 import * as DonorDataAccessLayer from "../dal/DonorDataAccessLayer";
-import { getAppointmentsByIds } from "../dal/AppointmentDataAccessLayer";
 
 export function removeDonorFromDbAppointment(
   appointment: DbAppointment
@@ -119,25 +118,6 @@ export function toBookedAppointmentSync(
       donor.bloodType
     );
   }
-}
-
-export async function getAppointmentById(
-  appointmentId: string
-): Promise<DbAppointment> {
-  const foundAppointments = await getAppointmentsByIds([appointmentId]);
-  return foundAppointments[0];
-}
-
-export async function getAppointmentByIdOrThrow(
-  appointmentId: string
-): Promise<DbAppointment> {
-  const appointment = await getAppointmentById(appointmentId);
-
-  if (!appointment) {
-    throw new Error("Appointment not found");
-  }
-
-  return appointment;
 }
 
 function manuallyBookedAppointmentToBookedAppointment(


### PR DESCRIPTION
getAppointmentById added, utilizing the original getAppointmentsByIds.

getAppointmentByIdOrThrow is the safe version, 
throwing instead of returning undefined, to standardize the resulting error.