### PR TITLE
Fix OnBack from Login to Donate page

### DIFF
--- a/packages/donor/src/screens/authentication/signin/SignInScreen.stories.tsx
+++ b/packages/donor/src/screens/authentication/signin/SignInScreen.stories.tsx
@@ -24,6 +24,7 @@ const props: SignInScreenProps = {
   onRegister: action("onRegister"),
   onResetPassword: action("onResetPassword"),
   onSignInWithEmail: onSignInWithEmail,
+  onBack: action("onBack"),
 };
 
 export const Default = (args: SignInScreenProps) => <SignInScreen {...args} />;

--- a/packages/donor/src/screens/authentication/signin/SignInScreen.tsx
+++ b/packages/donor/src/screens/authentication/signin/SignInScreen.tsx
@@ -15,6 +15,7 @@ export interface SignInScreenProps {
     emailError: (error: string) => void,
     passwordError: (error: string) => void
   ) => Promise<boolean>;
+  onBack: () => void;
 }
 
 export default function SignInScreen(props: SignInScreenProps) {
@@ -39,7 +40,12 @@ export default function SignInScreen(props: SignInScreenProps) {
   };
 
   return (
-    <ZMScreen className={styles.screenSection} padding hasBackButton>
+    <ZMScreen
+      className={styles.screenSection}
+      padding
+      hasBackButton
+      onBack={props.onBack}
+    >
       <div className={styles.screenContent}>
         <img
           src={LoginIllustration}

--- a/packages/donor/src/screens/authentication/signin/SignInScreenContainer.tsx
+++ b/packages/donor/src/screens/authentication/signin/SignInScreenContainer.tsx
@@ -16,11 +16,16 @@ export default function SignInScreenContainer(props: { loggedIn: boolean }) {
     navigate(MainNavigationKeys.ResetPassword);
   };
 
+  const onBack = () => {
+    navigate(MainNavigationKeys.BookDonation);
+  };
+
   return (
     <SignInScreen
       onSignInWithEmail={signInWithEmail}
       onRegister={onRegister}
       onResetPassword={onResetPassword}
+      onBack={onBack}
     />
   );
 }


### PR DESCRIPTION
Back button bugged out in Login Page,
redirecting back and then immediately re redirecting to the Login Page.

Fixed to redirect specifically to /donate

Steps:
1. Open the app on /donate page without being logged in.
2. In the hamburger menu, click on Profile and be redirected to Login
3. Click on the Back button.

Expected: 
Go back to /donate

Result: 
Stay on Login page

[Trello ticket](https://trello.com/c/1AWUrDMM/504-cannot-go-back-from-login)