### PR TITLE
Add last completed donation time to donor response

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -23,6 +23,7 @@ export type Donor = {
   phone: string;
   bloodType: BloodType;
   notificationSettings: DonorNotificationSettings;
+  lastCompletedDonationTimeMillis?: number;
 };
 
 export type MinimalDonorDetailsForAppointment = {

--- a/packages/functions/src/utils/ApiEntriesConversionUtils.ts
+++ b/packages/functions/src/utils/ApiEntriesConversionUtils.ts
@@ -7,7 +7,8 @@ export function dbDonorToDonor(dbDonor: DbDonor): Donor {
       disableEmailNotifications: false,
     };
 
-  const lastCompletedDonationTime = dbDonor.lastCompletedDonationTime?.toMillis(); 
+  const lastCompletedDonationTime =
+    dbDonor.lastCompletedDonationTime?.toMillis();
 
   return {
     ...dbDonor,

--- a/packages/functions/src/utils/ApiEntriesConversionUtils.ts
+++ b/packages/functions/src/utils/ApiEntriesConversionUtils.ts
@@ -7,8 +7,11 @@ export function dbDonorToDonor(dbDonor: DbDonor): Donor {
       disableEmailNotifications: false,
     };
 
+  const lastCompletedDonationTime = dbDonor.lastCompletedDonationTime?.toMillis(); 
+
   return {
     ...dbDonor,
+    lastCompletedDonationTimeMillis: lastCompletedDonationTime,
     notificationSettings: notificationSettings,
   };
 }


### PR DESCRIPTION
To check in the FE if[ enough days has passed between donations](https://trello.com/c/HYCpaIJy/459-donor-alert-pop-up-when-trying-to-book-an-appointment-less-than-a-month-since-previous-appointment), we need to have `lastCompletedDonationTime` data on the appState donor (converted to milli seconds as the rest of the dates in the fe)